### PR TITLE
fixed #3 if "pyproject.toml" does not exist, print the message to run `poetry init` first

### DIFF
--- a/pipenv_poetry_migrate/cli.py
+++ b/pipenv_poetry_migrate/cli.py
@@ -1,5 +1,10 @@
+import sys
 from argparse import ArgumentParser
 
+from pipenv_poetry_migrate.loader import (
+    PipfileNotFoundError,
+    PyprojectTomlNotFoundError,
+)
 from pipenv_poetry_migrate.migrate import PipenvPoetryMigration
 
 
@@ -14,11 +19,18 @@ def main():
     parser.add_argument("-n", "--dry-run", help="dry-run", action="store_true")
     args = parser.parse_args()
 
-    PipenvPoetryMigration(
-        args.pipfile,
-        args.pyproject_toml,
-        dry_run=args.dry_run,
-    ).migrate()
+    try:
+        PipenvPoetryMigration(
+            args.pipfile,
+            args.pyproject_toml,
+            dry_run=args.dry_run,
+        ).migrate()
+    except PipfileNotFoundError:
+        print(f"Pipfile '{args.pipfile}' not found")
+        sys.exit(1)
+    except PyprojectTomlNotFoundError:
+        print("Please run `poetry init` first")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/pipenv_poetry_migrate/loader.py
+++ b/pipenv_poetry_migrate/loader.py
@@ -1,0 +1,29 @@
+from tomlkit import loads
+from tomlkit.toml_document import TOMLDocument
+
+
+class PipfileNotFoundError(FileNotFoundError):
+    pass
+
+
+class PyprojectTomlNotFoundError(FileNotFoundError):
+    pass
+
+
+def load_toml(filepath) -> TOMLDocument:
+    with open(filepath, "r") as f:
+        return loads(f.read())
+
+
+def load_pipfile(filepath) -> TOMLDocument:
+    try:
+        return load_toml(filepath)
+    except FileNotFoundError as e:
+        raise PipfileNotFoundError from e
+
+
+def load_pyproject_toml(filepath) -> TOMLDocument:
+    try:
+        return load_toml(filepath)
+    except FileNotFoundError as e:
+        raise PyprojectTomlNotFoundError from e

--- a/pipenv_poetry_migrate/migrate.py
+++ b/pipenv_poetry_migrate/migrate.py
@@ -1,16 +1,12 @@
-from tomlkit import aot, dumps, inline_table, loads, table
-from tomlkit.toml_document import TOMLDocument
+from tomlkit import aot, dumps, inline_table, table
 
-
-def load_toml(filename) -> TOMLDocument:
-    with open(filename, "r") as f:
-        return loads(f.read())
+from pipenv_poetry_migrate.loader import load_pipfile, load_pyproject_toml
 
 
 class PipenvPoetryMigration(object):
     def __init__(self, pipfile: str, pyproject_toml: str, *, dry_run: bool = False):
-        self._pipenv = load_toml(pipfile)
-        self._pyproject = load_toml(pyproject_toml)
+        self._pipenv = load_pipfile(pipfile)
+        self._pyproject = load_pyproject_toml(pyproject_toml)
         self._pyproject_toml = pyproject_toml
         self._dry_run = dry_run
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import pytest
+from tomlkit.exceptions import ParseError
+from tomlkit.toml_document import TOMLDocument
+
+from pipenv_poetry_migrate.loader import (
+    PipfileNotFoundError,
+    PyprojectTomlNotFoundError,
+    load_pipfile,
+    load_pyproject_toml,
+    load_toml,
+)
+
+
+def test_load_toml(pyproject_toml: Path):
+    toml = load_toml(str(pyproject_toml))
+
+    assert isinstance(toml, TOMLDocument)
+    assert toml["tool"]["poetry"]["name"] == "pipenv-poetry-migrate-tests"
+
+
+def test_load_toml_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        load_toml("not_found.toml")
+
+
+def test_load_toml_parse_error():
+    with pytest.raises(ParseError):
+        load_toml("tests/toml/broken.toml")
+
+
+def test_load_pipfile(pipfile: Path):
+    toml = load_pipfile(str(pipfile))
+
+    assert isinstance(toml, TOMLDocument)
+
+
+def test_load_pipfile_fails_file_not_found():
+    with pytest.raises(PipfileNotFoundError):
+        load_pipfile("not_found.toml")
+
+
+def test_load_pyproject_toml(pyproject_toml: Path):
+    toml = load_pyproject_toml(str(pyproject_toml))
+
+    assert isinstance(toml, TOMLDocument)
+
+
+def test_load_pyproject_toml_fails_file_not_found():
+    with pytest.raises(PyprojectTomlNotFoundError):
+        load_pyproject_toml("not_found.toml")

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,26 +1,7 @@
 from pathlib import Path
 
-import pytest
-from tomlkit.exceptions import ParseError
-from tomlkit.toml_document import TOMLDocument
-
-from pipenv_poetry_migrate.migrate import PipenvPoetryMigration, load_toml
-
-
-def test_load_toml(pyproject_toml: Path):
-    toml = load_toml(str(pyproject_toml))
-    assert isinstance(toml, TOMLDocument)
-    assert toml["tool"]["poetry"]["name"] == "pipenv-poetry-migrate-tests"
-
-
-def test_load_toml_file_not_found():
-    with pytest.raises(FileNotFoundError):
-        load_toml("not_found.toml")
-
-
-def test_load_toml_parse_error():
-    with pytest.raises(ParseError):
-        load_toml("tests/toml/broken.toml")
+from pipenv_poetry_migrate.loader import load_toml
+from pipenv_poetry_migrate.migrate import PipenvPoetryMigration
 
 
 def test_migrate(


### PR DESCRIPTION
#3

If "pyproject.toml" does not exist, print the message to run `poetry init` first.

```
% poetry run python pipenv_poetry_migrate/cli.py -f ./tests/toml/Pipfile -t aaa -n
Please run `poetry init` first
```