### PR TITLE
:sparkles: #7 support the git dependencies format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,14 @@ jobs:
     - name: Install poetry
       run: |
         curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-        echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
+        source $HOME/.poetry/env
 
     - name: Install dependencies
       run: |
+        source $HOME/.poetry/env
         poetry install
 
     - name: Run Tox
       run: |
+        source $HOME/.poetry/env
         poetry run tox -e black,flake8,mypy,py

--- a/pipenv_poetry_migrate/translator.py
+++ b/pipenv_poetry_migrate/translator.py
@@ -1,0 +1,12 @@
+translate_property_map = {
+    "editable": "develop",
+    "ref": "rev",
+}
+
+
+def translate_properties(properties: dict) -> dict:
+    key_list = list(properties.keys())
+    for k in key_list:
+        if k in translate_property_map:
+            properties[translate_property_map[k]] = properties.pop(k)
+    return properties

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,0 +1,16 @@
+from pipenv_poetry_migrate.translator import translate_properties
+
+
+def test_translate_properties():
+    original = {
+        "git": "https://github.com/yhino/pipenv_poetry_migrate.git",
+        "ref": "develop",
+        "editable": True,
+    }
+
+    translated = translate_properties(original)
+    assert translated == {
+        "git": "https://github.com/yhino/pipenv_poetry_migrate.git",
+        "rev": "develop",
+        "develop": True,
+    }

--- a/tests/toml/Pipfile
+++ b/tests/toml/Pipfile
@@ -7,6 +7,8 @@ name = "pypi"
 requests = "*"
 "uvicorn[standard]" = {version="*", index="pypi"}
 "celery[redis,msgpack]" = "*"
+pipenv-poetry-migrate = {editable=true, git="https://github.com/yhino/pipenv-poetry-migrate.git", ref="master"}
+"flask[dotenv,dev]" = {git = "https://github.com/pallets/flask.git", ref = "1.1.1"}
 
 [dev-packages]
 pytest = "^5.2"

--- a/tests/toml/expect_pyproject.toml
+++ b/tests/toml/expect_pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.7"
 requests = "*"
 uvicorn = {extras = ["standard"], version="*", index="pypi"}
 celery = {extras = ["redis","msgpack"], version = "*"}
+pipenv-poetry-migrate = {git = "https://github.com/yhino/pipenv-poetry-migrate.git", rev = "master", develop = true}
+flask = {git = "https://github.com/pallets/flask.git", rev = "1.1.1", extras = ["dotenv", "dev"]}
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
#7 

The git dependency case was not considered. Supported by this fix.

refs.
- https://pipenv.pypa.io/en/latest/basics/#a-note-about-vcs-dependencies 
- https://python-poetry.org/docs/dependency-specification/#git-dependencies