### PR TITLE
:white_check_mark: fixed to get version from pyproject.toml when testing

### DIFF
--- a/tests/test_pipenv_poetry_migrate.py
+++ b/tests/test_pipenv_poetry_migrate.py
@@ -1,5 +1,9 @@
+import tomlkit
+
 from pipenv_poetry_migrate import __version__
 
 
 def test_version():
-    assert __version__ == "0.1.4"
+    with open("pyproject.toml", "r") as f:
+        p = tomlkit.loads(f.read())
+    assert __version__ == p["tool"]["poetry"]["version"]


### PR DESCRIPTION
Fixed to get version from pyproject.toml when testing.
