### PR TITLE
:wrench: suppress error output when getting a new version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NEW_VERSION := $(shell poetry run semantic-release print-version)
+NEW_VERSION := $(shell poetry run semantic-release print-version 2>/dev/null)
 
 release:
 ifneq ($(NEW_VERSION),)


### PR DESCRIPTION
Suppress the output of the error message when getting a new version.
