### PR TITLE
Fix issue and added test case where Pipfile item only contains extras…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint: clean
 	@poetry run mypy .
 
 test: clean
-	@poetry run pytest --verbose \
+	@poetry run pytest -vv \
 		--cov=pipenv_poetry_migrate \
 		--cov-report=term \
 		--cov-report=xml \

--- a/README.md
+++ b/README.md
@@ -103,5 +103,11 @@ requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
 ```
 
+## Contributing
+To run tests, :
+1) `poetry install`  # get environment setup
+2) `make test`      # run the tests
+Test cases are in `tests/toml`, update `Pipfile` with additional entries and `expect_pyproject.toml` with expected output
+
 ## License
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fyhino%2Fpipenv-poetry-migrate.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fyhino%2Fpipenv-poetry-migrate?ref=badge_large)

--- a/pipenv_poetry_migrate/migrate.py
+++ b/pipenv_poetry_migrate/migrate.py
@@ -97,4 +97,5 @@ class PipenvPoetryMigration(object):
             formatted.update(translate_properties(properties))
         else:
             formatted.append("version", properties)
-        return formatted["version"] if len(formatted) == 1 else formatted
+        return formatted["version"] if len(formatted) == 1 and "version" in formatted.keys() else formatted
+

--- a/tests/toml/Pipfile
+++ b/tests/toml/Pipfile
@@ -19,6 +19,7 @@ pipenv-poetry-migrate = {editable=true, git="https://github.com/yhino/pipenv-poe
 [dev-packages]
 pytest = "^5.2"
 isort = {extras = ["pyproject"], version = "^4.3.21"}
+werkzeug = {extras = ["watchdog"]}
 
 [scripts]
 test = "pytest --verbose tests"

--- a/tests/toml/expect_pyproject.toml
+++ b/tests/toml/expect_pyproject.toml
@@ -15,6 +15,7 @@ flask = {git = "https://github.com/pallets/flask.git", rev = "1.1.1", extras = [
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
 isort = {extras = ["pyproject"], version = "^4.3.21"}
+werkzeug = {extras = ["watchdog"]}
 
 [[tool.poetry.source]]
 name = 'private'


### PR DESCRIPTION
Hi, thanks for creating this tool. I fixed an issue and added new test case where in the Pipfile contains a line like: 

`werkzeug = {extras = ["watchdog"]}`

which caused the tool to crash. 

