### PR TITLE
support dependency group notation

### DIFF
--- a/pipenv_poetry_migrate/cli.py
+++ b/pipenv_poetry_migrate/cli.py
@@ -19,6 +19,12 @@ def main():
     parser.add_argument(
         "-t", "--pyproject-toml", type=str, required=True, help="path to pyproject.toml"
     )
+    parser.add_argument(
+        "--use-group-notation",
+        "--use-group",
+        help="migrate development dependencies with the new group notation",
+        action="store_true",
+    )
     parser.add_argument("-n", "--dry-run", help="dry-run", action="store_true")
     parser.add_argument(
         "-v", "--version", help="show version", action="version", version=__version__
@@ -29,6 +35,7 @@ def main():
         PipenvPoetryMigration(
             args.pipfile,
             args.pyproject_toml,
+            use_group_notation=args.use_group_notation,
             dry_run=args.dry_run,
         ).migrate()
     except PipfileNotFoundError:

--- a/pipenv_poetry_migrate/migrate.py
+++ b/pipenv_poetry_migrate/migrate.py
@@ -95,7 +95,7 @@ class PipenvPoetryMigration(object):
 
             # if there is no dependency, remove the traditional notation
             if len(self._pyproject["tool"]["poetry"]["dev-dependencies"]) < 1:
-                del self._pyproject["tool"]["poetry"]["dev-dependencies"]
+                self._pyproject["tool"]["poetry"].remove("dev-dependencies")
         else:
             self._migrate_dependencies(
                 pipenv_key="dev-packages", poetry_key="dev-dependencies"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,25 @@ def expect_pyproject_toml() -> Path:
 
 
 @pytest.fixture
+def expect_pyproject_toml_with_use_group_notation() -> Path:
+    return Path("tests/toml/expect_pyproject_with_use_group_notation.toml")
+
+
+@pytest.fixture
 def pipenv_poetry_migration(
     tmp_path: Path, pipfile: Path, pyproject_toml: Path
 ) -> PipenvPoetryMigration:
     replica_pyproject_toml = tmp_path / "pyproject.toml"
     replica_pyproject_toml.write_bytes(pyproject_toml.read_bytes())
     return PipenvPoetryMigration(str(pipfile), str(replica_pyproject_toml))
+
+
+@pytest.fixture
+def pipenv_poetry_migration_with_use_group_notation(
+    tmp_path: Path, pipfile: Path, pyproject_toml: Path
+) -> PipenvPoetryMigration:
+    replica_pyproject_toml = tmp_path / "pyproject.toml"
+    replica_pyproject_toml.write_bytes(pyproject_toml.read_bytes())
+    return PipenvPoetryMigration(
+        str(pipfile), str(replica_pyproject_toml), use_group_notation=True
+    )

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -12,3 +12,14 @@ def test_migrate(
     actual = load_toml(pipenv_poetry_migration.pyproject_toml())
     expect = load_toml(str(expect_pyproject_toml))
     assert actual == expect
+
+
+def test_migrate_with_use_group_notation(
+    pipenv_poetry_migration_with_use_group_notation: PipenvPoetryMigration,
+    expect_pyproject_toml_with_use_group_notation: Path,
+):
+    pipenv_poetry_migration_with_use_group_notation.migrate()
+
+    actual = load_toml(pipenv_poetry_migration_with_use_group_notation.pyproject_toml())
+    expect = load_toml(str(expect_pyproject_toml_with_use_group_notation))
+    assert actual == expect

--- a/tests/toml/expect_pyproject_with_use_group_notation.toml
+++ b/tests/toml/expect_pyproject_with_use_group_notation.toml
@@ -1,0 +1,26 @@
+[tool.poetry]
+name = "pipenv-poetry-migrate-tests"
+version = "0.1.0"
+description = ""
+authors = ["Yoshiyuki HINO <yhinoz@gmail.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+requests = "*"
+uvicorn = {extras = ["standard"], version="*", index="pypi"}
+celery = {extras = ["redis","msgpack"], version = "*"}
+pipenv-poetry-migrate = {git = "https://github.com/yhino/pipenv-poetry-migrate.git", rev = "master", develop = true}
+flask = {git = "https://github.com/pallets/flask.git", rev = "1.1.1", extras = ["dotenv", "dev"]}
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^5.2"
+isort = {extras = ["pyproject"], version = "^4.3.21"}
+werkzeug = {extras = ["watchdog"]}
+
+[[tool.poetry.source]]
+name = 'private'
+url = 'https://example.com/simple'
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Closes #23  

The `--use-group-notation` option enables migration in depenency group notation, which is supported in poetry 1.2.

Example usage is below:

```
% pipenv-poetry-migrate -f tests/toml/Pipfile -t tests/toml/pyproject.toml --use-group-notation -n
!!WARNING!! poetry does not have the function of task runner. migration of the scripts section will be skipped.
[tool.poetry]
name = "pipenv-poetry-migrate-tests"
version = "0.1.0"
description = ""
authors = ["Yoshiyuki HINO <yhinoz@gmail.com>"]

[tool.poetry.dependencies]
python = "^3.7"
requests = "*"
uvicorn = {extras = ["standard"], version = "*", index = "pypi"}
celery = {extras = ["redis", "msgpack"], version = "*"}
pipenv-poetry-migrate = {git = "https://github.com/yhino/pipenv-poetry-migrate.git", develop = true, rev = "master"}
flask = {extras = ["dotenv", "dev"], git = "https://github.com/pallets/flask.git", rev = "1.1.1"}

[[tool.poetry.source]]
name = "private"
url = "https://example.com/simple"

[tool.poetry.group.dev.dependencies]
pytest = "^5.2"
isort = {extras = ["pyproject"], version = "^4.3.21"}
werkzeug = {extras = ["watchdog"]}


[build-system]
requires = ["poetry>=0.12"]
build-backend = "poetry.masonry.api"
```