### PR TITLE
♻️ migrate argument parser to typer

### DIFF
--- a/pipenv_poetry_migrate/cli.py
+++ b/pipenv_poetry_migrate/cli.py
@@ -1,7 +1,6 @@
-import sys
-from argparse import ArgumentParser
+from typing import Optional
 
-import rich
+import typer
 
 from pipenv_poetry_migrate import __version__
 from pipenv_poetry_migrate.loader import (
@@ -10,43 +9,65 @@ from pipenv_poetry_migrate.loader import (
 )
 from pipenv_poetry_migrate.migrate import PipenvPoetryMigration
 
+app = typer.Typer()
 
-def main():
-    parser = ArgumentParser()
-    parser.add_argument(
-        "-f", "--pipfile", type=str, required=True, help="path to Pipfile"
-    )
-    parser.add_argument(
-        "-t", "--pyproject-toml", type=str, required=True, help="path to pyproject.toml"
-    )
-    parser.add_argument(
+
+def show_version(is_show: bool):
+    if is_show:
+        typer.echo(f"{__version__}")
+        raise typer.Exit()
+
+
+@app.command()
+def main(
+    pipfile: str = typer.Option(
+        ...,
+        "--pipfile",
+        "-f",
+        help="path to Pipfile",
+    ),
+    pyproject_toml: str = typer.Option(
+        ...,
+        "--pyproject-toml",
+        "-t",
+        help="path to pyproject.toml",
+    ),
+    use_group_notation: bool = typer.Option(
+        False,
         "--use-group-notation",
         "--use-group",
         help="migrate development dependencies with the new group notation",
-        action="store_true",
-    )
-    parser.add_argument("-n", "--dry-run", help="dry-run", action="store_true")
-    parser.add_argument(
-        "-v", "--version", help="show version", action="version", version=__version__
-    )
-    args = parser.parse_args()
-
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        "-n",
+        help="dry-run",
+    ),
+    _: Optional[bool] = typer.Option(
+        None,
+        "--version",
+        "-v",
+        help="show version",
+        callback=show_version,
+        is_eager=True,
+    ),
+):
+    """This is simple migration script, migrate pipenv to poetry"""
     try:
         PipenvPoetryMigration(
-            args.pipfile,
-            args.pyproject_toml,
-            use_group_notation=args.use_group_notation,
-            dry_run=args.dry_run,
+            pipfile,
+            pyproject_toml,
+            use_group_notation=use_group_notation,
+            dry_run=dry_run,
         ).migrate()
     except PipfileNotFoundError:
-        rich.print(f"[red]Pipfile '{args.pipfile}' not found", file=sys.stderr)
-        sys.exit(1)
+        typer.secho(f"Pipfile '{pipfile}' not found", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=1)
     except PyprojectTomlNotFoundError:
-        rich.print("[red]Please run `poetry init` first", file=sys.stderr)
-        sys.exit(1)
-    else:
-        sys.exit(0)
+        typer.secho("Please run `poetry init` first", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":
-    main()
+    app()

--- a/pipenv_poetry_migrate/cli.py
+++ b/pipenv_poetry_migrate/cli.py
@@ -19,7 +19,7 @@ def show_version(is_show: bool):
         raise typer.Exit()
 
 
-@app.command()
+@app.command(context_settings=dict(help_option_names=["-h", "--help"]))
 def main(
     pipfile: Path = typer.Option(
         ...,

--- a/pipenv_poetry_migrate/cli.py
+++ b/pipenv_poetry_migrate/cli.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Optional
 
 import typer
@@ -20,13 +21,13 @@ def show_version(is_show: bool):
 
 @app.command()
 def main(
-    pipfile: str = typer.Option(
+    pipfile: Path = typer.Option(
         ...,
         "--pipfile",
         "-f",
         help="path to Pipfile",
     ),
-    pyproject_toml: str = typer.Option(
+    pyproject_toml: Path = typer.Option(
         ...,
         "--pyproject-toml",
         "-t",

--- a/pipenv_poetry_migrate/loader.py
+++ b/pipenv_poetry_migrate/loader.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from tomlkit import loads
 from tomlkit.toml_document import TOMLDocument
 
@@ -10,19 +12,19 @@ class PyprojectTomlNotFoundError(FileNotFoundError):
     pass
 
 
-def load_toml(filepath) -> TOMLDocument:
-    with open(filepath, "r") as f:
+def load_toml(filepath: Path) -> TOMLDocument:
+    with filepath.open("r") as f:
         return loads(f.read())
 
 
-def load_pipfile(filepath) -> TOMLDocument:
+def load_pipfile(filepath: Path) -> TOMLDocument:
     try:
         return load_toml(filepath)
     except FileNotFoundError as e:
         raise PipfileNotFoundError from e
 
 
-def load_pyproject_toml(filepath) -> TOMLDocument:
+def load_pyproject_toml(filepath: Path) -> TOMLDocument:
     try:
         return load_toml(filepath)
     except FileNotFoundError as e:

--- a/pipenv_poetry_migrate/migrate.py
+++ b/pipenv_poetry_migrate/migrate.py
@@ -2,7 +2,7 @@ import re
 import sys
 from typing import Any, Dict, Optional, Tuple, Union
 
-import rich
+import typer
 from tomlkit import aot, dumps, inline_table, nl, table
 from tomlkit.container import Container
 from tomlkit.items import InlineTable, Table, Trivia
@@ -104,10 +104,11 @@ class PipenvPoetryMigration(object):
     def _migrate_scripts(self):
         if "scripts" not in self._pipenv:
             return
-        rich.print(
-            "[yellow]!!WARNING!! poetry does not have the function of task runner."
+        typer.secho(
+            ">>>WARNING<<< poetry does not have the function of task runner."
             " migration of the scripts section will be skipped.",
-            file=sys.stderr,
+            err=True,
+            fg=typer.colors.YELLOW,
         )
 
     @staticmethod

--- a/pipenv_poetry_migrate/migrate.py
+++ b/pipenv_poetry_migrate/migrate.py
@@ -1,5 +1,5 @@
 import re
-import sys
+from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Union
 
 import typer
@@ -14,8 +14,8 @@ from pipenv_poetry_migrate.translator import translate_properties
 class PipenvPoetryMigration(object):
     def __init__(
         self,
-        pipfile: str,
-        pyproject_toml: str,
+        pipfile: Path,
+        pyproject_toml: Path,
         *,
         use_group_notation: bool = False,
         dry_run: bool = False
@@ -26,7 +26,7 @@ class PipenvPoetryMigration(object):
         self._use_group_notation = use_group_notation
         self._dry_run = dry_run
 
-    def pyproject_toml(self) -> str:
+    def pyproject_toml(self) -> Path:
         return self._pyproject_toml
 
     def migrate(self):

--- a/poetry.lock
+++ b/poetry.lock
@@ -90,7 +90,7 @@ unicode_backport = ["unicodedata2"]
 name = "click"
 version = "8.0.1"
 description = "Composable command line interface toolkit"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -116,17 +116,6 @@ description = "Cross-platform colored terminal text."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-
-[[package]]
-name = "commonmark"
-version = "0.9.1"
-description = "Python parser for the CommonMark Markdown spec"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.extras]
-test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
 name = "coverage"
@@ -249,7 +238,7 @@ python-versions = ">=3.5"
 name = "importlib-metadata"
 version = "4.2.0"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -448,7 +437,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "pygments"
 version = "2.10.0"
 description = "Pygments is a syntax highlighting package written in Python."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
 
@@ -605,23 +594,6 @@ python-versions = "*"
 idna2008 = ["idna"]
 
 [[package]]
-name = "rich"
-version = "9.13.0"
-description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
-category = "main"
-optional = false
-python-versions = ">=3.6,<4.0"
-
-[package.dependencies]
-colorama = ">=0.4.0,<0.5.0"
-commonmark = ">=0.9.0,<0.10.0"
-pygments = ">=2.6.0,<3.0.0"
-typing-extensions = ">=3.7.4,<4.0.0"
-
-[package.extras]
-jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
-
-[[package]]
 name = "secretstorage"
 version = "3.3.1"
 description = "Python bindings to FreeDesktop.org Secret Service API"
@@ -763,6 +735,23 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "typer"
+version = "0.4.0"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+click = ">=7.1.1,<9.0.0"
+
+[package.extras]
+all = ["colorama (>=0.4.3,<0.5.0)", "shellingham (>=1.3.0,<2.0.0)"]
+dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)"]
+doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=5.4.0,<6.0.0)", "markdown-include (>=0.5.1,<0.6.0)"]
+test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "coverage (>=5.2,<6.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.910)", "black (>=19.10b0,<20.0b0)", "isort (>=5.0.6,<6.0.0)"]
+
+[[package]]
 name = "types-setuptools"
 version = "57.0.2"
 description = "Typing stubs for setuptools"
@@ -822,7 +811,7 @@ python-versions = "*"
 name = "zipp"
 version = "3.5.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -833,7 +822,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "5a94e96e63dd11c00e27f14cb8206ca18368d8e494d8d916a9e4b6e1cf6d2934"
+content-hash = "be1bea6ed76ef8a3d23018417adbecbee96b7e49571401b393bc22b798314ea7"
 
 [metadata.files]
 atomicwrites = [
@@ -940,10 +929,6 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
-commonmark = [
-    {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
-    {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
-]
 coverage = [
     {file = "coverage-6.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b27d894748475fa858f9597c0ee1d4829f44683f3813633aaf94b19cb5453cf"},
     {file = "coverage-6.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:37d1141ad6b2466a7b53a22e08fe76994c2d35a5b6b469590424a9953155afac"},
@@ -994,8 +979,6 @@ cryptography = [
     {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34dae04a0dce5730d8eb7894eab617d8a70d0c97da76b905de9efb7128ad7085"},
     {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1eb7bb0df6f6f583dd8e054689def236255161ebbcf62b226454ab9ec663746b"},
     {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:9965c46c674ba8cc572bc09a03f4c649292ee73e1b683adb1ce81e82e9a6a0fb"},
-    {file = "cryptography-3.4.8-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:3c4129fc3fdc0fa8e40861b5ac0c673315b3c902bbdc05fc176764815b43dd1d"},
-    {file = "cryptography-3.4.8-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:695104a9223a7239d155d7627ad912953b540929ef97ae0c34c7b8bf30857e89"},
     {file = "cryptography-3.4.8-cp36-abi3-win32.whl", hash = "sha256:21ca464b3a4b8d8e86ba0ee5045e103a1fcfac3b39319727bc0fc58c09c6aff7"},
     {file = "cryptography-3.4.8-cp36-abi3-win_amd64.whl", hash = "sha256:3520667fda779eb788ea00080124875be18f2d8f0848ec00733c0ec3bb8219fc"},
     {file = "cryptography-3.4.8-pp36-pypy36_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d2a6e5ef66503da51d2110edf6c403dc6b494cc0082f85db12f54e9c5d4c3ec5"},
@@ -1177,10 +1160,6 @@ rfc3986 = [
     {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
     {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
 ]
-rich = [
-    {file = "rich-9.13.0-py3-none-any.whl", hash = "sha256:9004f6449c89abadf689dad6f92393e760b8c3a8a8c4ea6d8d474066307c0e66"},
-    {file = "rich-9.13.0.tar.gz", hash = "sha256:d59e94a0e3e686f0d268fe5c7060baa1bd6744abca71b45351f5850a3aaa6764"},
-]
 secretstorage = [
     {file = "SecretStorage-3.3.1-py3-none-any.whl", hash = "sha256:422d82c36172d88d6a0ed5afdec956514b189ddbfb72fefab0c8a1cee4eaf71f"},
     {file = "SecretStorage-3.3.1.tar.gz", hash = "sha256:fd666c51a6bf200643495a04abb261f83229dcb6fd8472ec393df7ffc8b6f195"},
@@ -1256,6 +1235,10 @@ typed-ast = [
     {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
     {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
+]
+typer = [
+    {file = "typer-0.4.0-py3-none-any.whl", hash = "sha256:d81169725140423d072df464cad1ff25ee154ef381aaf5b8225352ea187ca338"},
+    {file = "typer-0.4.0.tar.gz", hash = "sha256:63c3aeab0549750ffe40da79a1b524f60e08a2cbc3126c520ebf2eeaf507f5dd"},
 ]
 types-setuptools = [
     {file = "types-setuptools-57.0.2.tar.gz", hash = "sha256:4ead432cc394b8de5ee94a312494f3c730d21dbfef37f300a6ac5e742271d735"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = 'README.md'
 [tool.poetry.dependencies]
 python = "^3.7"
 tomlkit = ">=0.5.11,<1.0.0"
-rich = "^9.6.1"
+typer = "^0.4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.1"
@@ -25,7 +25,7 @@ python-semantic-release = "^7.15.3"
 types-setuptools = "^57.0.0"
 
 [tool.poetry.scripts]
-pipenv-poetry-migrate = "pipenv_poetry_migrate.cli:main"
+pipenv-poetry-migrate = "pipenv_poetry_migrate.cli:app"
 
 [tool.isort]
 profile = "black"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,17 +29,17 @@ def expect_pyproject_toml_with_use_group_notation() -> Path:
 def pipenv_poetry_migration(
     tmp_path: Path, pipfile: Path, pyproject_toml: Path
 ) -> PipenvPoetryMigration:
-    replica_pyproject_toml = tmp_path / "pyproject.toml"
+    replica_pyproject_toml = tmp_path.joinpath("pyproject.toml")
     replica_pyproject_toml.write_bytes(pyproject_toml.read_bytes())
-    return PipenvPoetryMigration(str(pipfile), str(replica_pyproject_toml))
+    return PipenvPoetryMigration(pipfile, replica_pyproject_toml)
 
 
 @pytest.fixture
 def pipenv_poetry_migration_with_use_group_notation(
     tmp_path: Path, pipfile: Path, pyproject_toml: Path
 ) -> PipenvPoetryMigration:
-    replica_pyproject_toml = tmp_path / "pyproject.toml"
+    replica_pyproject_toml = tmp_path.joinpath("pyproject.toml")
     replica_pyproject_toml.write_bytes(pyproject_toml.read_bytes())
     return PipenvPoetryMigration(
-        str(pipfile), str(replica_pyproject_toml), use_group_notation=True
+        pipfile, replica_pyproject_toml, use_group_notation=True
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,57 +1,43 @@
-import sys
 from pathlib import Path
 
-import pytest
+from typer.testing import CliRunner
 
 from pipenv_poetry_migrate import __version__
-from pipenv_poetry_migrate.cli import main
+from pipenv_poetry_migrate.cli import app
+
+runner = CliRunner(mix_stderr=False)
 
 
-def test_main(monkeypatch, capfd, pipfile: Path, pyproject_toml: Path):
-    with monkeypatch.context() as m:
-        with pytest.raises(SystemExit) as e:
-            argv = ["-f", str(pipfile), "-t", str(pyproject_toml), "-n"]
-            m.setattr(sys, "argv", [""] + argv)
-            main()
+def test_main(pipfile: Path, pyproject_toml: Path):
+    argv = ["-f", str(pipfile), "-t", str(pyproject_toml), "-n"]
+    result = runner.invoke(app, argv)
 
-            assert e.value.code == 0
-        captured = capfd.readouterr()
-        assert captured.out != ""
+    assert result.exit_code == 0
+    assert result.stdout != ""
 
 
-def test_main_show_version(monkeypatch, capfd):
-    with monkeypatch.context() as m:
-        with pytest.raises(SystemExit) as e:
-            m.setattr(sys, "argv", ["", "-v"])
-            main()
+def test_main_show_version():
+    argv = ["-v"]
+    result = runner.invoke(app, argv)
 
-            assert e.value.code == 0
-        captured = capfd.readouterr()
-        assert __version__ in captured.out
-        assert captured.err == ""
+    assert result.exit_code == 0
+    assert __version__ in result.stdout
+    assert result.stderr == ""
 
 
-def test_main_raise_pipfile_not_found_error(monkeypatch, capfd, pyproject_toml: Path):
-    with monkeypatch.context() as m:
-        with pytest.raises(SystemExit) as e:
-            argv = ["-f", "not_found.toml", "-t", str(pyproject_toml), "-n"]
-            m.setattr(sys, "argv", [""] + argv)
-            main()
+def test_main_raise_pipfile_not_found_error(pyproject_toml: Path):
+    argv = ["-f", "not_found.toml", "-t", str(pyproject_toml), "-n"]
+    result = runner.invoke(app, argv)
 
-            assert e.value.code == 1
-        captured = capfd.readouterr()
-        assert captured.out == ""
-        assert "Pipfile 'not_found.toml' not found" in captured.err
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "Pipfile 'not_found.toml' not found" in result.stderr
 
 
-def test_main_raise_pyproject_toml_not_found_error(monkeypatch, capfd, pipfile: Path):
-    with monkeypatch.context() as m:
-        with pytest.raises(SystemExit) as e:
-            argv = ["-f", str(pipfile), "-t", "not_found.toml", "-n"]
-            m.setattr(sys, "argv", [""] + argv)
-            main()
+def test_main_raise_pyproject_toml_not_found_error(pipfile: Path):
+    argv = ["-f", str(pipfile), "-t", "not_found.toml", "-n"]
+    result = runner.invoke(app, argv)
 
-            assert e.value.code == 1
-        captured = capfd.readouterr()
-        assert captured.out == ""
-        assert "Please run `poetry init` first" in captured.err
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "Please run `poetry init` first" in result.stderr

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -14,7 +14,7 @@ from pipenv_poetry_migrate.loader import (
 
 
 def test_load_toml(pyproject_toml: Path):
-    toml = load_toml(str(pyproject_toml))
+    toml = load_toml(pyproject_toml)
 
     assert isinstance(toml, TOMLDocument)
     assert toml["tool"]["poetry"]["name"] == "pipenv-poetry-migrate-tests"
@@ -22,31 +22,31 @@ def test_load_toml(pyproject_toml: Path):
 
 def test_load_toml_file_not_found():
     with pytest.raises(FileNotFoundError):
-        load_toml("not_found.toml")
+        load_toml(Path("not_found.toml"))
 
 
 def test_load_toml_parse_error():
     with pytest.raises(ParseError):
-        load_toml("tests/toml/broken.toml")
+        load_toml(Path("tests/toml/broken.toml"))
 
 
 def test_load_pipfile(pipfile: Path):
-    toml = load_pipfile(str(pipfile))
+    toml = load_pipfile(pipfile)
 
     assert isinstance(toml, TOMLDocument)
 
 
 def test_load_pipfile_fails_file_not_found():
     with pytest.raises(PipfileNotFoundError):
-        load_pipfile("not_found.toml")
+        load_pipfile(Path("not_found.toml"))
 
 
 def test_load_pyproject_toml(pyproject_toml: Path):
-    toml = load_pyproject_toml(str(pyproject_toml))
+    toml = load_pyproject_toml(pyproject_toml)
 
     assert isinstance(toml, TOMLDocument)
 
 
 def test_load_pyproject_toml_fails_file_not_found():
     with pytest.raises(PyprojectTomlNotFoundError):
-        load_pyproject_toml("not_found.toml")
+        load_pyproject_toml(Path("not_found.toml"))

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -10,7 +10,7 @@ def test_migrate(
     pipenv_poetry_migration.migrate()
 
     actual = load_toml(pipenv_poetry_migration.pyproject_toml())
-    expect = load_toml(str(expect_pyproject_toml))
+    expect = load_toml(expect_pyproject_toml)
     assert actual == expect
 
 
@@ -21,5 +21,5 @@ def test_migrate_with_use_group_notation(
     pipenv_poetry_migration_with_use_group_notation.migrate()
 
     actual = load_toml(pipenv_poetry_migration_with_use_group_notation.pyproject_toml())
-    expect = load_toml(str(expect_pyproject_toml_with_use_group_notation))
+    expect = load_toml(expect_pyproject_toml_with_use_group_notation)
     assert actual == expect


### PR DESCRIPTION
Change the argument parser to [typer](https://github.com/tiangolo/typer).

With this change, the argument type could be defined as `pathlib.Path`.
All paths handled internally should use `pathlib.Path`.