### PR TITLE
:children_crossing: default migration to group notation

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,3 +8,5 @@ extend-exclude =
     .pytest_cache
     build
     dist
+extend-immutable-calls =
+    typer.Option

--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ When want to run dry-run mode:
 
 Dry-run mode is `pyproject.toml` file does not overwrite, results are displayed on standard output.
 
-:seedling: Use the `--use-group-notation` option if you want to migrate to [the new notation supported in poetry 1.2](https://python-poetry.org/docs/master/managing-dependencies/#dependency-groups).
-
-    $ pipenv-poetry-migrate -f Pipfile -t pyproject.toml --use-group-notation
+> **Note**: 
+> The default behavior is to migrate with the [group notation](https://python-poetry.org/docs/master/managing-dependencies/#dependency-groups), which has been available since Poetry 1.2.0.
+> If you want to migrate with `dev-dependencies` notation, please use the `--on-use-group-notation` option.
+> 
+>     $ pipenv-poetry-migrate -f Pipfile -t pyproject.toml --no-use-group-notation
 
 #### Step 3: Generate lock file
 

--- a/pipenv_poetry_migrate/cli.py
+++ b/pipenv_poetry_migrate/cli.py
@@ -34,9 +34,9 @@ def main(
         help="path to pyproject.toml",
     ),
     use_group_notation: bool = typer.Option(
-        False,
-        "--use-group-notation",
-        "--use-group",
+        True,
+        "--use-group-notation/--no-use-group-notation",
+        "--use-group/--no-use-group",
         help="migrate development dependencies with the new group notation",
     ),
     dry_run: bool = typer.Option(


### PR DESCRIPTION
The default behavior is to migrate with the [group notation](https://python-poetry.org/docs/master/managing-dependencies/#dependency-groups), which has been available since Poetry 1.2.0.

Poetry 1.3.0 has already been released and "group notation" should be used a lot.
The `dev-dependencies` will soon be deprecated and should not be used.