### PR TITLE
:construction_worker: do not run snyk action for Forked pull requests

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   analyze:
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
If the pull request is from a Forked repository, the snyk action will fail.
So, it is not run.