### PR TITLE
:sparkles: add `--re-migrate` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ When want to run dry-run mode:
 Dry-run mode is `pyproject.toml` file does not overwrite, results are displayed on standard output.
 
 > **Note**  
+> If the dependency already exists in the poetry dependency and you want to re-migrate it, please use the `--re-migrate` option.
+> However, if the dependency is removed from pipenv, the poetry dependency is not removed.
+>
+>     $ pipenv-poetry-migrate -f Pipfile -t pyproject.toml --re-migrate
+
+> **Note**  
 > The default behavior is to migrate with the [group notation](https://python-poetry.org/docs/master/managing-dependencies/#dependency-groups), which has been available since Poetry 1.2.0.
 > If you want to migrate with `dev-dependencies` notation, please use the `--on-use-group-notation` option.
 > 

--- a/pipenv_poetry_migrate/cli.py
+++ b/pipenv_poetry_migrate/cli.py
@@ -8,7 +8,7 @@ from pipenv_poetry_migrate.loader import (
     PipfileNotFoundError,
     PyprojectTomlNotFoundError,
 )
-from pipenv_poetry_migrate.migrate import PipenvPoetryMigration
+from pipenv_poetry_migrate.migrate import MigrationOption, PipenvPoetryMigration
 
 app = typer.Typer()
 
@@ -43,6 +43,14 @@ def main(
         "--use-group/--no-use-group",
         help="migrate development dependencies with the new group notation",
     ),
+    re_migrate: bool = typer.Option(
+        False,
+        "--re-migrate",
+        help="""
+            re-migrate a dependency if it already exists in the poetry dependency.
+            however, if a dependency is removed from pipenv, it does not remove the poetry dependency
+        """,
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
@@ -63,8 +71,11 @@ def main(
         PipenvPoetryMigration(
             pipfile,
             pyproject_toml,
-            use_group_notation=use_group_notation,
-            dry_run=dry_run,
+            option=MigrationOption(
+                use_group_notation=use_group_notation,
+                re_migrate=re_migrate,
+                dry_run=dry_run,
+            ),
         ).migrate()
     except PipfileNotFoundError as exc:
         typer.secho(f"Pipfile '{pipfile}' not found", err=True, fg=typer.colors.RED)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,10 +19,15 @@ def poetry12_pyproject_toml() -> Path:
 
 
 @pytest.fixture()
-def expect_pyproject_toml() -> Path:
-    return Path("tests/toml/expect_pyproject.toml")
+def expect_pyproject_toml_with_default_option() -> Path:
+    return Path("tests/toml/expect_pyproject_with_default_option.toml")
 
 
 @pytest.fixture()
-def expect_pyproject_toml_with_use_group_notation() -> Path:
-    return Path("tests/toml/expect_pyproject_with_use_group_notation.toml")
+def expect_pyproject_toml_with_no_use_group_notation() -> Path:
+    return Path("tests/toml/expect_pyproject_with_no_use_group_notation.toml")
+
+
+@pytest.fixture()
+def expect_pyproject_toml_with_re_migrate() -> Path:
+    return Path("tests/toml/expect_pyproject_with_re_migrate.toml")

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -3,7 +3,7 @@ from typing import Any, Callable
 
 import pytest
 from pipenv_poetry_migrate.loader import load_toml
-from pipenv_poetry_migrate.migrate import PipenvPoetryMigration
+from pipenv_poetry_migrate.migrate import MigrationOption, PipenvPoetryMigration
 
 
 @pytest.fixture()
@@ -17,11 +17,19 @@ def load_fixture(request: pytest.FixtureRequest) -> Callable[[str], Any]:
 @pytest.mark.parametrize(
     ("pipfile_", "pyproject_toml_", "expect_pyproject_toml_"),
     [
-        ("pipfile", "pyproject_toml", "expect_pyproject_toml"),
-        ("pipfile", "poetry12_pyproject_toml", "expect_pyproject_toml"),
+        (
+            "pipfile",
+            "pyproject_toml",
+            "expect_pyproject_toml_with_default_option",
+        ),
+        (
+            "pipfile",
+            "poetry12_pyproject_toml",
+            "expect_pyproject_toml_with_default_option",
+        ),
     ],
 )
-def test_migrate(
+def test_migrate_with_default_option(
     pipfile_: str,
     pyproject_toml_: str,
     expect_pyproject_toml_: str,
@@ -34,6 +42,7 @@ def test_migrate(
     pipenv_poetry_migrate = PipenvPoetryMigration(
         load_fixture(pipfile_),
         replica_pyproject_toml,
+        option=MigrationOption(),
     )
     pipenv_poetry_migrate.migrate()
 
@@ -48,16 +57,16 @@ def test_migrate(
         (
             "pipfile",
             "pyproject_toml",
-            "expect_pyproject_toml_with_use_group_notation",
+            "expect_pyproject_toml_with_no_use_group_notation",
         ),
         (
             "pipfile",
             "poetry12_pyproject_toml",
-            "expect_pyproject_toml_with_use_group_notation",
+            "expect_pyproject_toml_with_no_use_group_notation",
         ),
     ],
 )
-def test_migrate_with_use_group_notation(
+def test_migrate_with_no_use_group_notation(
     pipfile_: str,
     pyproject_toml_: str,
     expect_pyproject_toml_: str,
@@ -70,7 +79,48 @@ def test_migrate_with_use_group_notation(
     pipenv_poetry_migrate = PipenvPoetryMigration(
         load_fixture(pipfile_),
         replica_pyproject_toml,
-        use_group_notation=True,
+        option=MigrationOption(
+            use_group_notation=False,
+        ),
+    )
+    pipenv_poetry_migrate.migrate()
+
+    actual = load_toml(pipenv_poetry_migrate.pyproject_toml())
+    expect = load_toml(load_fixture(expect_pyproject_toml_))
+    assert actual == expect
+
+
+@pytest.mark.parametrize(
+    ("pipfile_", "pyproject_toml_", "expect_pyproject_toml_"),
+    [
+        (
+            "pipfile",
+            "pyproject_toml",
+            "expect_pyproject_toml_with_re_migrate",
+        ),
+        (
+            "pipfile",
+            "poetry12_pyproject_toml",
+            "expect_pyproject_toml_with_re_migrate",
+        ),
+    ],
+)
+def test_migrate_with_re_migrate(
+    pipfile_: str,
+    pyproject_toml_: str,
+    expect_pyproject_toml_: str,
+    tmp_path: Path,
+    load_fixture: Callable[[str], Any],
+) -> None:
+    replica_pyproject_toml = tmp_path.joinpath("pyproject")
+    replica_pyproject_toml.write_bytes(load_fixture(pyproject_toml_).read_bytes())
+
+    pipenv_poetry_migrate = PipenvPoetryMigration(
+        load_fixture(pipfile_),
+        replica_pyproject_toml,
+        option=MigrationOption(
+            re_migrate=True,
+        ),
     )
     pipenv_poetry_migrate.migrate()
 

--- a/tests/toml/Pipfile
+++ b/tests/toml/Pipfile
@@ -15,6 +15,7 @@ requests = "*"
 "celery[redis,msgpack]" = "*"
 pipenv-poetry-migrate = {editable=true, git="https://github.com/yhino/pipenv-poetry-migrate.git", ref="main"}
 "flask[dotenv,dev]" = {git = "https://github.com/pallets/flask.git", ref = "1.1.1"}
+numpy = "^1.25.2"
 
 [dev-packages]
 pytest = "^5.2"

--- a/tests/toml/expect_pyproject_with_default_option.toml
+++ b/tests/toml/expect_pyproject_with_default_option.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "pipenv-poetry-migrate-tests"
+version = "0.1.0"
+description = ""
+authors = ["Yoshiyuki HINO <yhinoz@gmail.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+requests = "*"
+uvicorn = {extras = ["standard"], version="*", source="pypi"}
+celery = {extras = ["redis","msgpack"], version = "*"}
+pipenv-poetry-migrate = {git = "https://github.com/yhino/pipenv-poetry-migrate.git", rev = "main", develop = true}
+flask = {git = "https://github.com/pallets/flask.git", rev = "1.1.1", extras = ["dotenv", "dev"]}
+numpy = "^1.24.4"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^5.2"
+isort = {extras = ["pyproject"], version = "^4.3.21"}
+werkzeug = {extras = ["watchdog"]}
+
+[[tool.poetry.source]]
+name = 'private'
+url = 'https://example.com/simple'
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/tests/toml/expect_pyproject_with_no_use_group_notation.toml
+++ b/tests/toml/expect_pyproject_with_no_use_group_notation.toml
@@ -11,6 +11,7 @@ uvicorn = {extras = ["standard"], version="*", source="pypi"}
 celery = {extras = ["redis","msgpack"], version = "*"}
 pipenv-poetry-migrate = {git = "https://github.com/yhino/pipenv-poetry-migrate.git", rev = "main", develop = true}
 flask = {git = "https://github.com/pallets/flask.git", rev = "1.1.1", extras = ["dotenv", "dev"]}
+numpy = "^1.24.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/tests/toml/expect_pyproject_with_re_migrate.toml
+++ b/tests/toml/expect_pyproject_with_re_migrate.toml
@@ -11,6 +11,7 @@ uvicorn = {extras = ["standard"], version="*", source="pypi"}
 celery = {extras = ["redis","msgpack"], version = "*"}
 pipenv-poetry-migrate = {git = "https://github.com/yhino/pipenv-poetry-migrate.git", rev = "main", develop = true}
 flask = {git = "https://github.com/pallets/flask.git", rev = "1.1.1", extras = ["dotenv", "dev"]}
+numpy = "^1.25.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^5.2"

--- a/tests/toml/poetry12_pyproject.toml
+++ b/tests/toml/poetry12_pyproject.toml
@@ -6,6 +6,7 @@ authors = ["Yoshiyuki HINO <yhinoz@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
+numpy = "^1.24.4"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/tests/toml/pyproject.toml
+++ b/tests/toml/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["Yoshiyuki HINO <yhinoz@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
+numpy = "^1.24.4"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
#62 

Add `--re-migrate` option.

The `--re-migrate` option re-migrates a dependency if it already exists in the poetry dependency.
However, if the dependency is removed from Pipfile, it does not remove the poetry dependency.