### PR TITLE
:alien: migration from pkg_resources to importlib_metadata

### DIFF
--- a/pipenv_poetry_migrate/__init__.py
+++ b/pipenv_poetry_migrate/__init__.py
@@ -1,3 +1,3 @@
-import pkg_resources
+import importlib.metadata
 
-__version__ = pkg_resources.get_distribution("pipenv-poetry-migrate").version
+__version__ = importlib.metadata.distribution("pipenv-poetry-migrate").version


### PR DESCRIPTION
The use of pkg_resources is deprecated. So migrate to importlib_metadata.
