### PR TITLE
:bug: fix python version required

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -983,5 +983,5 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8.1,<4.0"
-content-hash = "c356e3e40a637e8a2bbb104f50c55dd8037d9c23fdd4680f4cc43d54ddea7671"
+python-versions = ">=3.8,<4.0"
+content-hash = "90456ed6c7ec112bad8d4551524d0a5b4226f9e4e393dae48aee28438cd36c77"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ homepage = 'https://github.com/yhino/pipenv-poetry-migrate'
 readme = 'README.md'
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
+python = ">=3.8,<4.0"
 tomlkit = ">=0.12.1,<0.14.0"
 typer = ">=0.9,<0.13"
 


### PR DESCRIPTION
Some package dependency restricted it to 3.8.1 or higher. However, that package is not already in use.
Fix the required Python version to 3.8 or higher.