### PR TITLE
:bug: fix bash option in scripts

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -ue
 set -x
 
 rm -rf build dist .eggs *.egg-info

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -ue
 set -x
 
 poetry run ruff check --fix .

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -ue
 set -x
 
 poetry run mypy .

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 set -x
 
 export PYTHONPATH=.


### PR DESCRIPTION
Remove `set -ue`. Because the process should continue even if an error occurs.
