### PR TITLE
:wrench: change `allow_zero_version` to true

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ strict = true
 ignore_missing_imports = true
 
 [tool.semantic_release]
+allow_zero_version = true
 version_toml = ["pyproject.toml:tool.poetry.version"]
 commit_parser = "emoji"
 


### PR DESCRIPTION
https://python-semantic-release.readthedocs.io/en/stable/upgrading/10-upgrade.html#default-configuration-changes

I had overlooked the change to the default setting.
Set `allow_zero_version` to `true` to match the v9 configuration.